### PR TITLE
End-to-end ack on the repeater path: set the flag and gate retire on it

### DIFF
--- a/start.py
+++ b/start.py
@@ -296,7 +296,16 @@ class Main:
                             self.wirocLogger.debug("Start::handleInput() Received ack, for message id: " + Utils.GetDataInHex(messageID, logging.DEBUG) + " "
                                           + " receivedFromRepeater: " + str(receivedFromRepeater)
                                           + " destinationHasAcked: " + str(destinationHasAcked))
-                        DatabaseHelper.archive_message_subscriptions_after_ack(messageID, rssiValue, snrValue)
+                        # A repeater hop-ack (receivedFromRepeater, but destination not yet confirmed)
+                        # means the repeater has the message but the final receiver has not confirmed
+                        # it. Don't archive/retire the sender's message on that - the send block was
+                        # already extended above (BlockSendingToLetRepeaterSendAndReceiveAck), so keep
+                        # the message queued and let it retransmit (bounded by MaxTries) until the
+                        # end-to-end ack (destinationHasAcked) arrives. Every other case - a direct ack,
+                        # a confirmed repeater ack, or repeater mode - archives as before.
+                        repeaterHopAckOnly = (wiRocMode == "SENDER" and receivedFromRepeater and not destinationHasAcked)
+                        if not repeaterHopAckOnly:
+                            DatabaseHelper.archive_message_subscriptions_after_ack(messageID, rssiValue, snrValue)
 
     def handleOutput(self, settDict):
         #self.wirocLogger.debug("Handle output")

--- a/subscriberadapters/sendloraadapter.py
+++ b/subscriberadapters/sendloraadapter.py
@@ -214,10 +214,21 @@ class SendLoraAdapter(object):
             SendLoraAdapter.WiRocLogger.debug("SendLoraAdapter::BlockAfterReceivingAck lets go")
 
     def BlockSendingToLetRepeaterSendAndReceiveAck(self):
-        timeS = LoraRadioMessageRS.GetLoraMessageTimeSendingTimeSByMessageType(
-            LoraRadioMessageRS.MessageTypeSIPunchDoubleReDCoS) + \
-                LoraRadioMessageRS.GetLoraMessageTimeSendingTimeSByMessageType(
-                    LoraRadioMessageRS.MessageTypeLoraAck) + 0.35
+        # Block sending until the whole repeater round-trip can complete, so we don't
+        # retransmit while the message is still in flight:
+        #   repeater relays the punch to the receiver   -> 1x double-punch airtime
+        #   receiver acks the repeater                   -> 1x ack airtime
+        #   repeater acks back to this sender            -> 1x ack airtime  (was missing)
+        # The airtime terms scale with lora range (small at short range, large at long range).
+        # The +0.35 is a FIXED floor: at the fastest ranges the airtimes are tiny and the
+        # round-trip is dominated by fixed per-hop processing / main-loop latency, which does
+        # NOT scale down - so this floor must be >= that latency. 0.35 was the previous one-hop
+        # margin; TODO confirm it still covers the loop latency at the fastest ranges.
+        doublePunchTimeS = LoraRadioMessageRS.GetLoraMessageTimeSendingTimeSByMessageType(
+            LoraRadioMessageRS.MessageTypeSIPunchDoubleReDCoS)
+        ackTimeS = LoraRadioMessageRS.GetLoraMessageTimeSendingTimeSByMessageType(
+            LoraRadioMessageRS.MessageTypeLoraAck)
+        timeS = doublePunchTimeS + 2 * ackTimeS + 0.35
         self.blockSendingForSeconds = timeS
         self.blockSendingFromThisDate = datetime.now()
         self.blockSendingReason = "waitforrepeater"


### PR DESCRIPTION
Two linked fixes so a punch relayed via the repeater is only considered
delivered once the FINAL receiver confirms:

1. set_ack_received_from_receiver_on_repeater_lora_ack_message_subscription()
   queried a transform name that does not exist ('RepeaterToLoraAckTransform'),
   so AckReceivedFromReceiver was never set. It is consumed by
   RepeaterSIMessageToLoraAckTransform, which stamps it into the ack sent back
   to the sender (SetAckRequested), i.e. it is how the sender learns the
   receiver actually got the message. Match the real transform names
   (RepeaterSIMessageToLoraAckTransform / ...Double...).

2. On receiving an ACK the sender archived (deleted) its send record on ANY
   ack, including a bare repeater hop-ack that does not yet carry end-to-end
   confirmation. Combined with (1) this dropped punches that the repeater had
   acked but the base had never stored (observed when the base was briefly
   unavailable). Only archive when the final receiver has confirmed; otherwise
   keep the message queued so it retransmits (bounded by MaxTries).

Direct (non-repeater) delivery is unchanged, since the base's own ack is
end-to-end.
